### PR TITLE
chore(exports): add exports to package.json for svelte

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,5 +57,10 @@
         "tslib": "^2.3.1",
         "typescript": "^4.7.2",
         "vite": "^3.1.0-beta.1"
-    }
+    },
+    "exports": {
+        ".": {
+          "svelte": "./src/lib/index.ts"
+        }
+    }    
 }


### PR DESCRIPTION
This resolves the issue: 

> [vite-plugin-svelte] WARNING: The following packages have a svelte field in their package.json but no exports condition for svelte.

svelte-codemirror-editor@1.1.0