### PR TITLE
Expose EditorView up to the parent component after initialization

### DIFF
--- a/src/lib/CodeMirror.svelte
+++ b/src/lib/CodeMirror.svelte
@@ -35,8 +35,7 @@
     export let nodebounce = false;
 
     const is_browser = typeof window !== "undefined";
-    const dispatch = createEventDispatcher<{ change: string }>();
-    const dispatchReady = createEventDispatcher<{ ready: string }>();
+    const dispatch = createEventDispatcher<{ change: string, ready: EditorView }>();
 
     let element: HTMLDivElement;
     let view: EditorView;
@@ -59,7 +58,7 @@
 
     onMount(() => {
         view = create_editor_view();
-        dispatchReady(view);
+        dispatch('ready', view);
     });
     onDestroy(() => view?.destroy());
 

--- a/src/lib/CodeMirror.svelte
+++ b/src/lib/CodeMirror.svelte
@@ -36,6 +36,7 @@
 
     const is_browser = typeof window !== "undefined";
     const dispatch = createEventDispatcher<{ change: string }>();
+    const dispatchReady = createEventDispatcher<{ ready: string }>();
 
     let element: HTMLDivElement;
     let view: EditorView;
@@ -56,7 +57,10 @@
 
     $: on_change = nodebounce ? handle_change : debounce(handle_change, 300);
 
-    onMount(() => (view = create_editor_view()));
+    onMount(() => {
+        view = create_editor_view();
+        dispatchReady(view);
+    });
     onDestroy(() => view?.destroy());
 
     function create_editor_view(): EditorView {


### PR DESCRIPTION
Thanks for this great component! 

I need to be able to access the EditorView in my parent component. This PR makes the CodeMirror component dispatch a 'ready' event that includes the EditorView, after it has been initialized.