### PR TITLE
feat: expose editorview on reconfigure via emit

### DIFF
--- a/src/lib/CodeMirror.svelte
+++ b/src/lib/CodeMirror.svelte
@@ -35,7 +35,7 @@
     export let nodebounce = false;
 
     const is_browser = typeof window !== "undefined";
-    const dispatch = createEventDispatcher<{ change: string, ready: EditorView }>();
+    const dispatch = createEventDispatcher<{ change: string, ready: EditorView, reconfigure: EditorView }>();
 
     let element: HTMLDivElement;
     let view: EditorView;
@@ -85,6 +85,8 @@
         view.dispatch({
             effects: StateEffect.reconfigure.of(state_extensions),
         });
+        
+        dispatch('reconfigure', view);
     }
 
     function update(value: string | null | undefined): void {


### PR DESCRIPTION
Follow up to #31.

Actually it turns out I need access to the EditorView again after it is reconfigured, as that seems to revert my change. This adds another event `on:reconfigure` that also includes the EditorView.

Thanks again @SomaticIT 